### PR TITLE
Fix missing exception variable in catch block in tok3.js.

### DIFF
--- a/javascript/tok3.js
+++ b/javascript/tok3.js
@@ -318,7 +318,7 @@ function try_compress(src, use_arith) {
 	    var tmp = use_arith
 		? arith.encode(src, lvl)
 		: rans.encode(src, lvl)
-	} catch {
+	} catch (e) {
 	    var tmp = 0
 	}
 	if (tmp && best > tmp.length) {


### PR DESCRIPTION
Minor fix in name tokenizer code (I get syntax errors without this change).