### PR TITLE
Fix javascript arith decode by creating a new class instance on the fly

### DIFF
--- a/javascript/index.js
+++ b/javascript/index.js
@@ -54,7 +54,7 @@ function r4x16_uncompress(inputBuffer, outputBuffer) {
 }
 
 function arith_uncompress(inputBuffer, outputBuffer) {
-    arith.decode(inputBuffer).copy(outputBuffer, 0, 0);
+    new arith().decode(inputBuffer).copy(outputBuffer, 0, 0);
 }
 
 function fqzcomp_uncompress(inputBuffer, outputBuffer) {


### PR DESCRIPTION
Hi there,
I saw the announcement that samtools was moving to cram 3.1 by default, and wanted to make sure our @gmod/cram still worked. I just did a preliminary check and the level3.cram from the hts-specs cram test data folder was failing

I believe it is because arith is a class, and an instance of it needs to be created to make it work

Hope this helps :)
